### PR TITLE
Fixed minification failure by adding explicit declaration of parameters for dependency injection.

### DIFF
--- a/src/adaptive-googlemaps.js
+++ b/src/adaptive-googlemaps.js
@@ -140,7 +140,7 @@
 
   }]);
 
-  adaptive.directive('googlemaps', [ "$parse", function ($parse) {
+  adaptive.directive('googlemaps', [ '$parse', function ($parse) {
     return {
       template: '<a ng-style="style" ng-href="{{MAP_HREF}}" target="_blank"></a>',
       replace: true,


### PR DESCRIPTION
The lack of explicit declaration for dependency injection caused failure when building a minified version of an application that uses adaptive-googlemaps.

Added explicit declaration of parameters for dependency injection.
